### PR TITLE
Move Atomizer after Indexifier in Pipeline

### DIFF
--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -16,8 +16,8 @@ Awestruct::Extensions::Pipeline.new do
   # extension Downloads.new()
 
   extension Awestruct::Extensions::Posts.new( '/news' )
-  extension Awestruct::Extensions::Atomizer.new( :posts, '/news.atom' )
   extension Awestruct::Extensions::Indexifier.new
+  extension Awestruct::Extensions::Atomizer.new( :posts, '/news.atom' )
   extension Awestruct::Extensions::Disqus.new
   extension Awestruct::Extensions::Flattr.new
   extension Awestruct::Extensions::Paginator.new( :posts, '/news/index',


### PR DESCRIPTION
The Indexifier change the given page's output_path so
the Atomizer need to be placed after the Indexifier to
avoid all URL references in the atom feed pointing to the
wrong URL.

Atom Feed URL:
http://escalante.io/news/2013/02/21/why-jbossas-scala.html

Site URL:
http://escalante.io/news/2013/02/21/why-jbossas-scala/
